### PR TITLE
fix(sqp): Ensure the challenge token is reset

### DIFF
--- a/lib/svrquery/protocol/sqp/challenge.go
+++ b/lib/svrquery/protocol/sqp/challenge.go
@@ -44,3 +44,8 @@ func (q *queryer) readChallenge() (err error) {
 	q.challengeID, err = q.reader.ReadUint32()
 	return err
 }
+
+// resetChallenge resets the challengeID so a new one will be generated when needed.
+func (q *queryer) resetChallenge() {
+	q.challengeID = 0
+}

--- a/lib/svrquery/protocol/sqp/query.go
+++ b/lib/svrquery/protocol/sqp/query.go
@@ -64,6 +64,9 @@ func (q *queryer) sendQuery(requestedChunks byte) error {
 		return err
 	}
 
+	// We can only use a challenge once so ensure it's reset.
+	defer q.resetChallenge()
+
 	_, err := q.c.Write(pkt.Bytes())
 	return err
 }


### PR DESCRIPTION
Challenge tokens are only valid for one request to ensure it's reset each time it's used.