### PR TITLE
ci: switch to goreleaser for releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,13 +2,20 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ["1.25"]
+
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.3
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
+
+    - name: Install Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: ${{ matrix.go }}
+
     - name: Test
       run: go test ./...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,11 @@
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
 name: Test
 jobs:
   test:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,23 +3,20 @@ on:
     types: [ created ]
 
 jobs:
-  releases-matrix:
+  goreleaser:
     name: Release Go Binary
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [ linux, windows, darwin ]
-        goarch: [ "386", amd64 ]
-        exclude:
-          - goarch: "386"
-            goos: darwin
     steps:
-      - uses: actions/checkout@v2
-      - uses: wangyoucao577/go-release-action@v1.17
+      - uses: actions/checkout@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: 1.20.3
-          project_path: "./cmd/cli"
-          binary_name: "go-svrquery"
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+# GoReleaser configuration
+version: 2
+
+before:
+  hooks:
+    # Ensure dependencies are up to date
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: go-svrquery
+    main: ./cmd/cli
+    binary: go-svrquery
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'

--- a/lib/svrquery/client_test.go
+++ b/lib/svrquery/client_test.go
@@ -10,35 +10,19 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	cases := []struct {
-		name     string
-		protocol string
-		addr     string
-		err      bool
-	}{
-		{
-			name:     "tf2e",
-			protocol: "tf2e",
-		},
-		{
-			name:     "invalid-protocol",
-			protocol: "my-protocol",
-			err:      true,
-		},
-	}
+	addr := "localhost:8000"
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			c, err := NewClient(tc.protocol, tc.addr, WithKey("test"), WithTimeout(time.Second))
-			if tc.err {
-				require.Error(t, err)
-				require.Nil(t, c)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, c)
-			}
-		})
-	}
+	t.Run("tf2e", func(t *testing.T) {
+		c, err := NewClient("tf2e", addr, WithKey("test"), WithTimeout(time.Second))
+		require.NoError(t, err)
+		require.NotNil(t, c)
+	})
+
+	t.Run("invalid-protocol", func(t *testing.T) {
+		c, err := NewClient("my-protocol", addr, WithKey("test"), WithTimeout(time.Second))
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
 }
 
 func TestQuery(t *testing.T) {


### PR DESCRIPTION
Switch to using goreleaser for managing releases and building binaries.